### PR TITLE
Fix riesgo multicompañia

### DIFF
--- a/account_financial_risk/models/res_partner.py
+++ b/account_financial_risk/models/res_partner.py
@@ -231,7 +231,7 @@ class ResPartner(models.Model):
             partner = self.browse(
                 group["commercial_partner_id"][0], self._prefetch)
             amount = group["amount_total_company_signed"]
-            company_currency = self.env['res.company'].browse(
+            company_currency = self.sudo().env['res.company'].browse(
                 group['company_id'][0]).currency_id
             partner.risk_invoice_draft = company_currency.compute(
                 amount, partner.risk_currency_id, round=False)


### PR DESCRIPTION


  -  [FIX] account_financial_risk: añadido sudo para evitar error en el cálculo del riesgo compañía

Buenos días,
nos ha llegado una incidencia que, al entrar en la ficha de un cliente, nos da error de permisos de lectura en el objeto de compañía. Este parche lo solucionaría, por lo que si lo veis bien, necesitaríamos meterlo en nuestro proyecto.
Saludos,
